### PR TITLE
feat(api): rate limit auth and invite endpoints [TRI-22]

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,29 @@
+import type { NextRequest } from "next/server";
 import { handlers } from "@/lib/auth";
+import { checkRateLimit, RateLimiters } from "@/lib/middlewares/rate-limit.middleware";
+import { handleError } from "@/lib/middlewares/error.middleware";
 
-export const { GET, POST } = handlers;
+/** App Router catch-all segment for `app/api/auth/[...nextauth]/route.ts` */
+type NextAuthRouteContext = { params: Promise<{ nextauth: string[] }> };
+
+export async function GET(req: NextRequest, context: NextAuthRouteContext) {
+  try {
+    await checkRateLimit(req, null, RateLimiters.authRead);
+    return handlers.GET(req, context);
+  } catch (error) {
+    return handleError(error);
+  }
+}
+
+export async function POST(req: NextRequest, context: NextAuthRouteContext) {
+  try {
+    await checkRateLimit(req, null, {
+      ...RateLimiters.auth,
+      keyPrefix: "auth-post",
+      message: "Too many authentication attempts. Please try again later.",
+    });
+    return handlers.POST(req, context);
+  } catch (error) {
+    return handleError(error);
+  }
+}

--- a/app/api/invites/[token]/route.ts
+++ b/app/api/invites/[token]/route.ts
@@ -1,36 +1,37 @@
-import type { NextRequest } from "next/server";
 import { inviteService } from "@/src/modules/invites/invite.service";
-import { withMiddleware, successResponse, createdResponse } from "@/lib/http";
+import { createAppRouteGetHandler, createAppRoutePostHandler } from "@/lib/factories";
 import { ApiErrors } from "@/lib/middlewares";
+import { RateLimiters } from "@/lib/middlewares/rate-limit.middleware";
 
-type Params = { params: Promise<{ token: string }> };
+type InvitePreviewPayload = {
+  projectId: string;
+  projectName: string;
+  role: string;
+  expiresAt: Date;
+};
 
-export function GET(req: NextRequest, { params }: Params) {
-  return withMiddleware(
-    async () => {
-      const { token } = await params;
-      const result = await inviteService.getInviteByToken(token);
-      if ("error" in result) {
-        if (result.error === "INVALID_INVITE") throw ApiErrors.NotFound("Invalid invite token");
-        throw ApiErrors.Gone("Invite has expired or already been accepted");
-      }
-      return successResponse(result.data);
-    },
-    { optionalAuth: true }
-  )(req);
-}
+/** OpenAPI: see `src/modules/invites/invite.swagger.ts` */
+export const GET = createAppRouteGetHandler<{ token: string }, InvitePreviewPayload>(
+  async (_req, _context, params) => {
+    const result = await inviteService.getInviteByToken(params.token);
+    if ("error" in result) {
+      if (result.error === "INVALID_INVITE") throw ApiErrors.NotFound("Invalid invite token");
+      throw ApiErrors.Gone("Invite has expired or already been accepted");
+    }
+    return result.data;
+  },
+  { optionalAuth: true, rateLimit: RateLimiters.inviteTokenPreview }
+);
 
-export function POST(req: NextRequest, { params }: Params) {
-  return withMiddleware(
-    async (_r, context) => {
-      const { token } = await params;
-      const result = await inviteService.acceptInvite(token, String(context.user!.id));
-      if ("error" in result) {
-        if (result.error === "INVALID_INVITE") throw ApiErrors.NotFound("Invalid invite token");
-        throw ApiErrors.Gone("Invite has expired or already been accepted");
-      }
-      return createdResponse(result.data);
-    },
-    { auth: true }
-  )(req);
-}
+/** OpenAPI: see `src/modules/invites/invite.swagger.ts` */
+export const POST = createAppRoutePostHandler<{ token: string }, { projectId: string }>(
+  async (_req, context, params) => {
+    const result = await inviteService.acceptInvite(params.token, String(context.user!.id));
+    if ("error" in result) {
+      if (result.error === "INVALID_INVITE") throw ApiErrors.NotFound("Invalid invite token");
+      throw ApiErrors.Gone("Invite has expired or already been accepted");
+    }
+    return result.data;
+  },
+  { auth: true, rateLimit: RateLimiters.inviteAccept }
+);

--- a/app/api/invites/route.ts
+++ b/app/api/invites/route.ts
@@ -1,49 +1,14 @@
-import type { NextRequest } from "next/server";
 import { inviteService } from "@/src/modules/invites/invite.service";
 import { createInviteSchema } from "@/src/modules/invites/invite.schema";
-import { withMiddleware, createdResponse } from "@/lib/http";
+import { createPostHandler } from "@/lib/factories";
 import { assertProjectAdmin } from "@/lib/auth-helpers";
-import { ApiErrors } from "@/lib/middlewares";
+import { RateLimiters } from "@/lib/middlewares/rate-limit.middleware";
 
-/**
- * @openapi
- * /api/invites:
- *   post:
- *     tags: [Invites]
- *     summary: Generate an invite link (ADMIN or OWNER only)
- *     security:
- *       - CookieAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             required: [projectId]
- *             properties:
- *               projectId:
- *                 type: string
- *               role:
- *                 type: string
- *                 enum: [ADMIN, MEMBER, VIEWER]
- *                 default: MEMBER
- *     responses:
- *       201:
- *         description: Invite token
- *       401:
- *         $ref: '#/components/responses/Unauthorized'
- *       403:
- *         $ref: '#/components/responses/Forbidden'
- */
-export function POST(req: NextRequest) {
-  return withMiddleware(
-    async (_r, context) => {
-      const validated = createInviteSchema.parse((_r as any).__validatedBody);
-      await assertProjectAdmin(validated.projectId, String(context.user!.id));
-      
-      const result = await inviteService.createInvite(validated, String(context.user!.id));
-      return createdResponse(result);
-    },
-    { auth: true, validateBody: createInviteSchema }
-  )(req);
-}
+/** OpenAPI: see `src/modules/invites/invite.swagger.ts` */
+export const POST = createPostHandler(
+  async (_req, context, validated) => {
+    await assertProjectAdmin(validated.projectId, String(context.user!.id));
+    return inviteService.createInvite(validated, String(context.user!.id));
+  },
+  { auth: true, validateBody: createInviteSchema, rateLimit: RateLimiters.generateInvite }
+);

--- a/lib/factories/handler.factory.ts
+++ b/lib/factories/handler.factory.ts
@@ -173,12 +173,12 @@ export function createAppRoutePatchHandler<TParams extends Record<string, string
  */
 export function createAppRoutePostHandler<TParams extends Record<string, string>, TData>(
   handler: (req: NextRequest, context: RequestContext, params: TParams, validated: unknown) => Promise<TData>,
-  config: HandlerConfig & { validateBody: z.Schema }
+  config: HandlerConfig
 ) {
   return async (req: NextRequest, segment: AppRouteParams<TParams>) => {
     const params = await segment.params;
     return withMiddleware(async (r, context) => {
-      const validated = (r as any).__validatedBody;
+      const validated = config.validateBody ? (r as any).__validatedBody : undefined;
       const data = await handler(r, context, params, validated);
       return createdResponse(data);
     }, config)(req);

--- a/lib/middlewares/rate-limit.middleware.ts
+++ b/lib/middlewares/rate-limit.middleware.ts
@@ -14,6 +14,8 @@ export interface RateLimitConfig {
   window: string; // Time window: '1s', '1m', '1h', '1d'
   message?: string; // Custom error message
   keyPrefix?: string; // Custom key prefix
+  /** When set, used instead of the request URL pathname (avoids unbounded keys for dynamic routes). */
+  pathKey?: string;
 }
 
 interface WindowEntry {
@@ -47,7 +49,7 @@ function parseWindowMs(window: string): number {
 function getRateLimitKey(req: Request, user: AuthUser | null, config: RateLimitConfig): string {
   const prefix = config.keyPrefix ?? "ratelimit";
   const identifier = user ? `user:${user.id}` : `ip:${getClientIp(req)}`;
-  const endpoint = new URL(req.url).pathname;
+  const endpoint = config.pathKey ?? new URL(req.url).pathname;
   return `${prefix}:${endpoint}:${identifier}`;
 }
 
@@ -101,14 +103,41 @@ export function withRateLimit(config: RateLimitConfig) {
  * Pre-configured rate limiters for Arbitask endpoints
  */
 export const RateLimiters = {
-  // Auth endpoints — tight
+  // Auth endpoints — tight (POST: sign-in, callbacks, sign-out)
   auth: { max: 5, window: "15m" } satisfies RateLimitConfig,
+
+  /** Auth.js GET traffic (session, CSRF, providers) — per-IP, fixed bucket */
+  authRead: {
+    max: 120,
+    window: "1m",
+    keyPrefix: "auth-read",
+    pathKey: "/api/auth",
+  } satisfies RateLimitConfig,
 
   // Mutation endpoints
   createProject: { max: 20, window: "1h" } satisfies RateLimitConfig,
   createTask: { max: 60, window: "1h" } satisfies RateLimitConfig,
   createNote: { max: 30, window: "1h" } satisfies RateLimitConfig,
   generateInvite: { max: 10, window: "1h" } satisfies RateLimitConfig,
+
+  /**
+   * Public invite preview (GET /api/invites/:token) — IP keyed with a stable path
+   * so attackers cannot mint unbounded store keys by varying the token.
+   */
+  inviteTokenPreview: {
+    max: 40,
+    window: "15m",
+    keyPrefix: "invite-preview",
+    pathKey: "/api/invites/[token]",
+  } satisfies RateLimitConfig,
+
+  /** Accept invite (POST) — authenticated; keyed per user */
+  inviteAccept: {
+    max: 30,
+    window: "1h",
+    keyPrefix: "invite-accept",
+    pathKey: "/api/invites/[token]",
+  } satisfies RateLimitConfig,
 
   // Read endpoints — generous
   read: { max: 200, window: "1m" } satisfies RateLimitConfig,

--- a/lib/swagger/routes/auth.ts
+++ b/lib/swagger/routes/auth.ts
@@ -18,6 +18,12 @@
  *         description: Auth.js response (varies by sub-route)
  *       302:
  *         description: Redirect (OAuth flow)
+ *       429:
+ *         description: Rate limit exceeded (GET traffic is throttled per IP)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *   post:
  *     tags:
  *       - Auth
@@ -32,5 +38,11 @@
  *         description: Auth.js response (varies by sub-route)
  *       302:
  *         description: Redirect (after sign-in/sign-out)
+ *       429:
+ *         description: Rate limit exceeded (sign-in attempts and other POST auth traffic)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 export {};

--- a/src/modules/invites/invite.swagger.ts
+++ b/src/modules/invites/invite.swagger.ts
@@ -45,6 +45,12 @@
  *         $ref: '#/components/responses/Unauthorized'
  *       403:
  *         $ref: '#/components/responses/Forbidden'
+ *       429:
+ *         description: Rate limit exceeded for invite generation
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *
  * /api/invites/{token}:
  *   get:
@@ -72,6 +78,12 @@
  *         description: Invalid invite token
  *       410:
  *         description: Invite expired or already accepted
+ *       429:
+ *         description: Rate limit exceeded for invite preview lookups
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  *   post:
  *     tags:
  *       - Invites
@@ -103,6 +115,12 @@
  *         description: Invalid invite token
  *       410:
  *         description: Invite expired or already accepted
+ *       429:
+ *         description: Rate limit exceeded for invite acceptance
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
  */
 
 /**


### PR DESCRIPTION
## Summary
Implements TRI-22: rate limiting on sensitive auth and invite surfaces.

## Changes
- Auth.js route: rate limit before delegating to handlers (GET: authRead, POST: strict auth bucket).
- Invites: handler factories + RateLimiters; stable pathKey for invite token routes.
- RateLimitConfig.pathKey to avoid unbounded store keys.
- createAppRoutePostHandler: optional validateBody for POST without JSON body.
- OpenAPI: 429 on auth and invite paths.

## Note
Local npm run was blocked by disk space in the agent environment; please confirm Swagger at /api/docs/ui on preview.

Linear: TRI-22

Made with [Cursor](https://cursor.com)